### PR TITLE
Fixed problem with correlation added to tfModules in runSCENIC_1_coexNetwork2modules

### DIFF
--- a/R/runSCENIC_1_coexNetwork2modules.R
+++ b/R/runSCENIC_1_coexNetwork2modules.R
@@ -104,7 +104,7 @@ runSCENIC_1_coexNetwork2modules <- function(scenicOptions)
   tfModules_withCorr_byTF <- lapply(tfModules_byTF[tfs], function(tfGeneSets)
   {
     tf <- unique(tfGeneSets$TF)
-    targets <- tfGeneSets$Target
+    targets <- as.character(tfGeneSets$Target)
     cbind(tfGeneSets, corr=c(as.numeric(corrMat[tf,targets] > 0.03) - as.numeric(corrMat[tf,targets] < -0.03)))
   })
   tfModules_withCorr <- data.frame(data.table::rbindlist(tfModules_withCorr_byTF))

--- a/R/runSCENIC_2_createRegulons.R
+++ b/R/runSCENIC_2_createRegulons.R
@@ -22,7 +22,7 @@ runSCENIC_2_createRegulons <- function(scenicOptions)
   nCores <- getSettings(scenicOptions, "nCores")
   
   # Set cores for RcisTarget::addMotifAnnotation(). The other functions use foreach package.
-  if("BiocParallel" %in% installed.packages()) library(BiocParallel); register(MulticoreParam(nCores), default=TRUE) 
+  #if("BiocParallel" %in% installed.packages()) library(BiocParallel); register(MulticoreParam(nCores), default=TRUE) 
   
   msg <- paste0(format(Sys.time(), "%H:%M"), "\tStep 2. Identifying regulons")
   if(getSettings(scenicOptions, "verbose")) message(msg)

--- a/R/runSCENIC_2_createRegulons.R
+++ b/R/runSCENIC_2_createRegulons.R
@@ -22,7 +22,7 @@ runSCENIC_2_createRegulons <- function(scenicOptions)
   nCores <- getSettings(scenicOptions, "nCores")
   
   # Set cores for RcisTarget::addMotifAnnotation(). The other functions use foreach package.
-  #if("BiocParallel" %in% installed.packages()) library(BiocParallel); register(MulticoreParam(nCores), default=TRUE) 
+  if("BiocParallel" %in% installed.packages()) library(BiocParallel); register(MulticoreParam(nCores), default=TRUE) 
   
   msg <- paste0(format(Sys.time(), "%H:%M"), "\tStep 2. Identifying regulons")
   if(getSettings(scenicOptions, "verbose")) message(msg)

--- a/vignettes/detailedStep_1_coexNetwork2modules.Rmd
+++ b/vignettes/detailedStep_1_coexNetwork2modules.Rmd
@@ -156,7 +156,7 @@ tfModules_byTF <- split(tfModules, factor(tfModules$TF))
 tfModules_withCorr_byTF <- lapply(tfModules_byTF[tfs], function(tfGeneSets)
 {
   tf <- unique(tfGeneSets$TF)
-  targets <- tfGeneSets$Target
+  targets <- as.character(tfGeneSets$Target)
   cbind(tfGeneSets, corr=c(as.numeric(corrMat[tf,targets] > 0.03) - as.numeric(corrMat[tf,targets] < -0.03)))
 })
 tfModules_withCorr <- data.frame(data.table::rbindlist(tfModules_withCorr_byTF))


### PR DESCRIPTION
Encountered an issue with `runSCENIC_1_coexNetwork2modules`.
When subsetting the `corrMat` using the `targets` from the `tfModules`. If the target vector is handled as a factor, subsetting the `CorrMat` using the factor will result in wrong correlations being considered for the genes and classification of correlations between TF and genes (1,0 or -1) in the downstream table `tfModules_withCorr` will be wrong. This then directly affect the downstream enrichment analysis of TF motifs since "wrong" positive correlated genes would be considered. 

Setting the `targets` vector `as.character ` makes sure that the subset of genes from the correlation Matrix is correct.