### PR TITLE
addresses issue 168 by parameterizing checkAnnots rnktype

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SCENIC
 Type: Package
 Title: SCENIC (Single Cell rEgulatory Network Inference and Clustering)
-Version: 1.3.1
+Version: 1.3.1.9001
 Date: 2022-05-02
 Author: Sara Aibar, Carmen Bravo, Stein Aerts. 
   Laboratory of Computational Biology, KU Leuven Center for Human Genetics. 

--- a/R/class_ScenicOptions.R
+++ b/R/class_ScenicOptions.R
@@ -452,7 +452,7 @@ initializeScenic <- function(org=NULL, dbDir="databases", dbs=NULL, datasetTitle
   
   ## Check if motif annotation and rankings potentially match
   motifAnnot <- getDbAnnotations(object)
-  featuresWithAnnot <- checkAnnots(object, motifAnnot)
+  featuresWithAnnot <- checkAnnots(object, motifAnnot, col = dbIndexCol)
   if(any(featuresWithAnnot == 0)) message("Missing annotations for: \n", paste("\t", names(which(featuresWithAnnot==0))))
   
   ## Return
@@ -494,12 +494,12 @@ dbLoadingAttempt <- function(dbFilePath, indexCol='features'){
 
 #' @rdname ScenicOptions-class
 #' @export 
-checkAnnots <- function(object, motifAnnot)
+checkAnnots <- function(object, motifAnnot, col)
 {
   allFeaturesInAnnot <- unlist(motifAnnot[,1]) # motif or track
   featuresWithAnnot <-  lapply(getDatabases(object), function(dbFile) 
   {
-    rnktype = "features"	#TODO: add as option for custom dbs
+    rnktype = col	#TODO: add as option for custom dbs
     nRnks <- getRanking(RcisTarget::importRankings(dbFile, columns = rnktype))
     nRnks <- dplyr::pull(nRnks, rnktype)
 

--- a/R/runSCENIC_2_createRegulons.R
+++ b/R/runSCENIC_2_createRegulons.R
@@ -79,7 +79,7 @@ runSCENIC_2_createRegulons <- function(scenicOptions,
 	})))
   
   ## Check if annotation and rankings (potentially) match:
-  featuresWithAnnot <- checkAnnots(scenicOptions, motifAnnot)
+  featuresWithAnnot <- checkAnnots(scenicOptions, motifAnnot, col = dbIndexCol)
   if(any(featuresWithAnnot == 0)) warning("Missing annotations\n", names(which(rankingsInDb==0)))
   
   ### Filter & format co-expression modules


### PR DESCRIPTION
I encountered errors with initializeScenic() and runSCENIC_2_createRegulons() using the mm10 databases.  These changes pass the dbIndexCol parameter through to the internal checkAnnots function.  This was tested successfully using your R tutorial and the mm10 .feather files provided.